### PR TITLE
Initiate date directly instead of modifying parts

### DIFF
--- a/validate-norwegian-ssn.js
+++ b/validate-norwegian-ssn.js
@@ -29,15 +29,12 @@
   'use strict';
 
   function isValidDate(str) {
-    var newdate = new Date();
     var yyyy = 2000 + Number(str.substr(4, 2));
-    var mm = Number(str.substr(2, 2)) - 1;
+    var mm = Number(str.substr(2, 2));
     var dd = Number(str.substr(0, 2));
-    newdate.setFullYear(yyyy);
-    newdate.setDate(dd);
-    newdate.setMonth(mm);
+    var newdate = new Date(`${yyyy}-${mm}-${dd}`);
 
-    return dd === newdate.getDate() && mm === newdate.getMonth() && yyyy === newdate.getFullYear();
+    return dd === newdate.getDate() && (mm - 1) === newdate.getMonth() && yyyy === newdate.getFullYear();
   }
 
   /**


### PR DESCRIPTION
This to avoid setting date or month going to the next month automatically.

The case which gives a bug is:
 - The current month has less than days than the given date
 - When the date is set, it set the month to the next month, while also setting the date to the number of days too many for the original month. 

Example: Today is 2020-02-11. Setting the date to 30 will make the date object be 2020-03-01. Which already breaks the package